### PR TITLE
Bugfix // Enum.empty

### DIFF
--- a/content/en/functions/Enum/empty_-1.md
+++ b/content/en/functions/Enum/empty_-1.md
@@ -1,7 +1,8 @@
 ---
 title: empty?/1
-url: Enum/empty/1
-aliases: ['/Enum/empty?/1']
+url: Enum/empty_/1
+aliases:
+  - '/Enum/empty?/1/'
 ---
 
 Returns `true` if the enumerable is empty.


### PR DESCRIPTION
## Overview
This PR fixes a broken link to the Enum.empty?/1 function on the index page. 

The issue was caused by inconsistent URL format in the function's markdown file. This did not appear in local development (only on [the site](https://superruzafa.github.io/visual-elixir-reference/)). I think this should fix it

### Details
The link to [empty?/1](https://superruzafa.github.io/visual-elixir-reference/Enum/empty%3F/1) doesn't work. I think this is because of a missing underscore - I compared it to other functions with `?` in them, and always found an underscore - for example: [all?/1](https://superruzafa.github.io/visual-elixir-reference/Enum/all%3F/1/) ([Code](https://github.com/superruzafa/visual-elixir-reference/blob/edd8bb548b5b8b9e93843bf086f456d96d707c30/content/en/functions/Enum/all_-1.md?plain=1#L3))


